### PR TITLE
Defining variable body on line 85

### DIFF
--- a/pretty_html_table/pretty_html_table.py
+++ b/pretty_html_table/pretty_html_table.py
@@ -82,6 +82,7 @@ def build_table(df, color, font_size = 'medium', font_family = 'Century Gothic',
     color, border_bottom, odd_background_color, header_background_color = table_color(color)
 
     #build html table
+    body = ""
     a = 0
     while a != len(df):
         if a == 0:        


### PR DESCRIPTION
If an empty DataFrame is passed as an argument to build_table(), the while loop will never run and thus line 141 will throw "Variable referenced before assignment" error as the variable "body" is referenced on line 141. "body" is never defined as it is defined in the loop that has not been run. Defining variable body before the loop will remove this error.