### PR TITLE
Feature/add override padding floats and colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Several optional arguments now exist that allow the user to control the table's 
 * `even_color` - accepts string representation of colors (either "white" or "FFFFF"). For instance, for the font color of the even lines to be white, you would write: even_color='white'.
 * `color` - accepts string representation of colors (either "white" or "FFFFF"). For instance, for the background color of the even lines to be black, you would write: even_color='black'.
 * `conditions` - accepts dictionnary providing the following information: <name_of_column>: `{'min': <min range>,'max': <max range>,'min_color': <color_for_min>,'max_color': <color_for_max>}` Below is an exmaple, if a column name is "Age" and we wish to have the ages represented in red if they are under 25 and green if they are over 60.
+* `padding` - accepts a string to set the CSS padding in the table (`10px`, `0px 20px`, `0px 20px 0px 0px`) 
+* `odd_bg_color` - accepts a hex or standard color for the odd row background 
+* `border_bottom_color` - accepts a color for the bottom border for the headers
 
 
 ```

--- a/pretty_html_table/pretty_html_table.py
+++ b/pretty_html_table/pretty_html_table.py
@@ -28,8 +28,8 @@ def build_table(
         index=False, 
         even_color='black', 
         even_bg_color='white', 
-        override_odd_bg_color=None,
-        override_border_bottom_color=None,
+        odd_bg_color=None,
+        border_bottom_color=None,
         escape=True,
         width_dict=[],
         padding="0px 20px 0px 0px",
@@ -42,11 +42,11 @@ def build_table(
     # Set color
     color, border_bottom, odd_background_color, header_background_color = dict_colors[color]
 
-    if override_odd_bg_color:
-        odd_background_color = override_odd_bg_color
+    if odd_bg_color:
+        odd_background_color = odd_bg_color
 
-    if override_border_bottom_color:
-        border_bottom = override_border_bottom_color 
+    if border_bottom_color:
+        border_bottom = border_bottom_color 
 
     a = 0
     while a != len(df):

--- a/pretty_html_table/pretty_html_table.py
+++ b/pretty_html_table/pretty_html_table.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import io
 
 # Reformat table_color as dict of tuples
@@ -29,21 +28,36 @@ def build_table(
         index=False, 
         even_color='black', 
         even_bg_color='white', 
+        override_odd_bg_color=None,
+        override_border_bottom_color=None,
         escape=True,
         width_dict=[],
+        padding="0px 20px 0px 0px",
+        float_format=None,
         conditions={}):
 
     if df.empty:
       return ''
      
     # Set color
-    padding="0px 20px 0px 0px"
     color, border_bottom, odd_background_color, header_background_color = dict_colors[color]
+
+    if override_odd_bg_color:
+        odd_background_color = override_odd_bg_color
+
+    if override_border_bottom_color:
+        border_bottom = override_border_bottom_color 
 
     a = 0
     while a != len(df):
         if a == 0:        
-            df_html_output = df.iloc[[a]].to_html(na_rep = "", index = index, border = 0, escape=escape)
+            df_html_output = df.iloc[[a]].to_html(
+                na_rep="", 
+                index=index, 
+                border=0, 
+                escape=escape, 
+                float_format=float_format,
+            )
             # change format of header
             if index:
                 df_html_output = df_html_output.replace('<th>'
@@ -196,9 +210,6 @@ def build_table(
                 body = width_body[:len(width_body)-1]
             except:
                 pass
-
-
-
 
     if len(width_dict) == len(df.columns):
         width_body = ''


### PR DESCRIPTION
Adding the options to override:

- padding and float format (e.g. `float_format=lambda x: '%.2f' % x`)
- header border bottom color
- odd background colour