### PR TITLE
Tweak spaces around equal signs to improve compatibility with Outlook Web Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Several optional arguments now exist that allow the user to control the table's 
 * `index` - bolean. False by default - If you write index=True, index of the dataframe will then be visible in your table.
 * `even_color` - accepts string representation of colors (either "white" or "FFFFF"). For instance, for the font color of the even lines to be white, you would write: even_color='white'.
 * `color` - accepts string representation of colors (either "white" or "FFFFF"). For instance, for the background color of the even lines to be black, you would write: even_color='black'.
-* `conditions` - accepts dictionnary providing the following information: <name_of_column>: `{'min': <min range>,'max': <max range>,'min_color': <color_for_min>,'max_color': <color_for_max>}` Below is an exmaple, if a column name is "Age" and we wish to have the ages represented in red if they are under 25 and green if they are over 60.
+* `conditions` - accepts dictionary providing the following information: <name_of_column>: `{'min': <min range>,'max': <max range>,'min_color': <color_for_min>,'max_color': <color_for_max>}` Below is an exmaple, if a column name is "Age" and we wish to have the ages represented in red if they are under 25 and green if they are over 60.
 * `padding` - accepts a string to set the CSS padding in the table (`10px`, `0px 20px`, `0px 20px 0px 0px`) 
 * `odd_bg_color` - accepts a hex or standard color for the odd row background 
 * `border_bottom_color` - accepts a color for the bottom border for the headers

--- a/pretty_html_table/pretty_html_table.py
+++ b/pretty_html_table/pretty_html_table.py
@@ -61,7 +61,7 @@ def build_table(
             # change format of header
             if index:
                 df_html_output = df_html_output.replace('<th>'
-                                                        ,'<th style = "background-color: ' + header_background_color
+                                                        ,'<th style="background-color: ' + header_background_color
                                                         + ';font-family: ' + font_family
                                                         + ';font-size: ' + str(font_size)
                                                         + ';color: ' + color
@@ -71,7 +71,7 @@ def build_table(
                                                         + ';width: ' + str(width) + '">', len(df.columns)+1)
 
                 df_html_output = df_html_output.replace('<th>'
-                                                        ,'<th style = "background-color: ' + odd_background_color
+                                                        ,'<th style="background-color: ' + odd_background_color
                                                         + ';font-family: ' + font_family
                                                         + ';font-size: ' + str(font_size)
                                                         + ';text-align: ' + text_align
@@ -80,7 +80,7 @@ def build_table(
 
             else:
                 df_html_output = df_html_output.replace('<th>'
-                                                        ,'<th style = "background-color: ' + header_background_color
+                                                        ,'<th style="background-color: ' + header_background_color
                                                         + ';font-family: ' + font_family
                                                         + ';font-size: ' + str(font_size)
                                                         + ';color: ' + color
@@ -91,7 +91,7 @@ def build_table(
 
             #change format of table
             df_html_output = df_html_output.replace('<td>'
-                                                    ,'<td style = "background-color: ' + odd_background_color
+                                                    ,'<td style="background-color: ' + odd_background_color
                                                     + ';font-family: ' + font_family
                                                     + ';font-size: ' + str(font_size)
                                                     + ';text-align: ' + text_align
@@ -106,7 +106,7 @@ def build_table(
              
             # change format of index
             df_html_output = df_html_output.replace('<th>'
-                                                    ,'<th style = "background-color: ' + odd_background_color
+                                                    ,'<th style="background-color: ' + odd_background_color
                                                     + ';font-family: ' + font_family
                                                     + ';font-size: ' + str(font_size)
                                                     + ';text-align: ' + text_align
@@ -115,7 +115,7 @@ def build_table(
 
             #change format of table
             df_html_output = df_html_output.replace('<td>'
-                                                    ,'<td style = "background-color: ' + odd_background_color
+                                                    ,'<td style="background-color: ' + odd_background_color
                                                     + ';font-family: ' + font_family
                                                     + ';font-size: ' + str(font_size)
                                                     + ';text-align: ' + text_align
@@ -131,7 +131,7 @@ def build_table(
              
             # change format of index
             df_html_output = df_html_output.replace('<th>'
-                                                    ,'<th style = "background-color: ' + even_bg_color
+                                                    ,'<th style="background-color: ' + even_bg_color
                                                     + '; color: ' + even_color
                                                     + ';font-family: ' + font_family
                                                     + ';font-size: ' + str(font_size)
@@ -141,7 +141,7 @@ def build_table(
              
             #change format of table
             df_html_output = df_html_output.replace('<td>'
-                                                    ,'<td style = "background-color: ' + even_bg_color
+                                                    ,'<td style="background-color: ' + even_bg_color
                                                     + '; color: ' + even_color
                                                     + ';font-family: ' + font_family
                                                     + ';font-size: ' + str(font_size)


### PR DESCRIPTION
Current version of Outlook Web Access strips the formatting out of tables when there are spaces around the = in the `<th style = "....>` and `<td style = "....>` tags. It works fine with the spaces on either side of the = removed, so this PR removes those. The [HTML5 spec](https://dev.w3.org/html5/spec-LC/syntax.html#unquoted) calls for zero or more spaces, so zero should be fine.

This should close #26 (or at least my issues with it). I also included a tiny typo fix to the README.